### PR TITLE
[fix] #66 메인뷰 패딩 값 수정

### DIFF
--- a/ChilledCafe/Views/Main/CategoryButtonView.swift
+++ b/ChilledCafe/Views/Main/CategoryButtonView.swift
@@ -11,14 +11,15 @@ struct CategoryButtonView: View {
     let title: String
     
     var body: some View {
-        VStack {
+        VStack(spacing: 6) {
             // MARK: - 카테고리 아이콘
             Image("\(Icon(rawValue: title) ?? .ocean)")
+                .resizable()
+                .frame(width: UIScreen.getWidth(30), height: UIScreen.getHeight(30))
             // MARK: - 카테고리 명
             Text(title)
                 .customSubhead3()
         }
-        .frame(width: UIScreen.getWidth(80), height: UIScreen.getHeight(86))
     }
 }
 

--- a/ChilledCafe/Views/Main/HorizontalScrollMenuBarView.swift
+++ b/ChilledCafe/Views/Main/HorizontalScrollMenuBarView.swift
@@ -11,6 +11,7 @@ struct HorizontalScrollMenuBarView: View {
     @State var choosed: Int = 0
     @ObservedObject var firebaseSM: FirebaseStorageManager
     var category: [String]
+    let spacing: CGFloat = UIScreen.getHeight(8)
     
     init(category: [String], firebaseSM: FirebaseStorageManager) {
         self.firebaseSM = firebaseSM
@@ -23,7 +24,7 @@ struct HorizontalScrollMenuBarView: View {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(alignment: .bottom , spacing: 0) {
                     // MARK: - 여백
-                    VStack {
+                    VStack(spacing: spacing) {
                         Circle()
                             .frame(width:UIScreen.getWidth(20), height: 1)
                             .hidden()
@@ -33,7 +34,7 @@ struct HorizontalScrollMenuBarView: View {
                     }
                     // MARK: - 카테고리
                     ForEach(Array(category.enumerated()), id: \.0) { index, item in
-                        VStack {
+                        VStack(spacing: spacing) {
                             CategoryButtonView(title: "\(item)")
                                 .foregroundColor(index == choosed ? Color("MainColor") : Color("CustomGray2"))
                                 .id(index)
@@ -42,6 +43,7 @@ struct HorizontalScrollMenuBarView: View {
                                     firebaseSM.selectedCategory = item
                                     withAnimation { proxy.scrollTo(index, anchor: UnitPoint.center) }
                                 }
+                                .fixedSize()
                             Rectangle()
                                 .frame(width: UIScreen.getWidth(88) ,height: UIScreen.getHeight(2))
                                 .foregroundColor(index == choosed ? Color("MainColor") : Color("CustomGray3"))
@@ -49,7 +51,7 @@ struct HorizontalScrollMenuBarView: View {
                         
                     }
                     // MARK: - 여백
-                    VStack {
+                    VStack(spacing: spacing) {
                         Circle()
                             .frame(width:UIScreen.getWidth(20), height: 1)
                             .hidden()
@@ -58,7 +60,15 @@ struct HorizontalScrollMenuBarView: View {
                             .foregroundColor(Color("CustomGray3"))
                     }
                 }
+                .frame(height: UIScreen.getHeight(66))
             }
         }
+    }
+}
+
+
+struct HorizontalScrollMenuBarView_Previews: PreviewProvider {
+    static var previews: some View {
+        HorizontalScrollMenuBarView(category: ["바다와 함께", "리버뷰"], firebaseSM: FirebaseStorageManager())
     }
 }

--- a/ChilledCafe/Views/Main/MainView.swift
+++ b/ChilledCafe/Views/Main/MainView.swift
@@ -11,8 +11,8 @@ struct MainView: View {
     @StateObject var firebaseSM: FirebaseStorageManager = FirebaseStorageManager()
     
     var body: some View {
-            VStack {
-                HStack {
+        VStack(spacing: 0) {
+                HStack(alignment: .center) {
                     Image("AppTitle")
                         .resizable()
                         .frame(width: UIScreen.getWidth(100), height: UIScreen.getHeight(30))
@@ -42,8 +42,8 @@ struct MainView: View {
     }
 }
 
-//struct MainView_Previews: PreviewProvider {
-//    static var previews: some View {
-//        MainView()
-//    }
-//}
+struct MainView_Previews: PreviewProvider {
+    static var previews: some View {
+        MainView()
+    }
+}


### PR DESCRIPTION

<img src = "https://user-images.githubusercontent.com/67509011/201590026-98fee8a8-323a-4916-97d6-35526e4812e9.png" width="30%" height="30%">

## 작업사항
- 메인뷰 로고 패딩값을 수정하였습니다. https://github.com/Chilled-Run/ChilledCafe/commit/8d4cce9bd542058988b896ce1f34ce161db32e1d
- 스크롤 카테고리 버튼 패딩값을 수정하였습니다. https://github.com/Chilled-Run/ChilledCafe/commit/a906f1cfb9415be295f18566a3366465b0a7a5fc

## 이슈 번호

- https://github.com/Chilled-Run/ChilledCafe/issues/66