### PR TITLE
[fix] #69 북마크뷰, 분위기뷰 back button 색상 위치 통일

### DIFF
--- a/ChilledCafe.xcodeproj/project.pbxproj
+++ b/ChilledCafe.xcodeproj/project.pbxproj
@@ -548,9 +548,9 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_ASSET_PATHS = "\"ChilledCafe/Preview Content\"";
-				DEVELOPMENT_TEAM = Y6P5ZFWBM8;
+				DEVELOPMENT_TEAM = PQ5FS4VVLR;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ChilledCafe/Info.plist;
@@ -564,7 +564,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ChilledCafe;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -582,9 +582,9 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_ASSET_PATHS = "\"ChilledCafe/Preview Content\"";
-				DEVELOPMENT_TEAM = Y6P5ZFWBM8;
+				DEVELOPMENT_TEAM = PQ5FS4VVLR;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ChilledCafe/Info.plist;
@@ -598,7 +598,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ChilledCafe;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/ChilledCafe/Views/Bookmark/MyBookmarkView.swift
+++ b/ChilledCafe/Views/Bookmark/MyBookmarkView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct MyBookmarkView: View {
     @ObservedObject var firebaseSM: FirebaseStorageManager
+    @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
     
     init(firebaseSM: FirebaseStorageManager){
         self.firebaseSM = firebaseSM
@@ -26,8 +27,22 @@ struct MyBookmarkView: View {
             }
         }
         .navigationBarTitleDisplayMode(.inline)
+        .navigationBarBackButtonHidden(true)
+        .navigationBarItems(leading: backButton)
         .navigationBarTitle("내가 갈 카페")
         .padding(EdgeInsets(top: UIScreen.getHeight(20), leading: 0, bottom: 0, trailing: 0))
+    }
+    
+    // MARK: 뒤로가기 버튼
+    var backButton: some View {
+        Button(action: {
+            self.presentationMode.wrappedValue.dismiss()
+        }) {
+            HStack {
+                Image(systemName: "chevron.backward")
+                    .foregroundColor(Color("MainColor"))
+            }
+        }
     }
 }
 

--- a/ChilledCafe/Views/MoodView/MoodView.swift
+++ b/ChilledCafe/Views/MoodView/MoodView.swift
@@ -75,7 +75,7 @@ struct MoodView: View {
         }) {
             HStack {
                 Image(systemName: "chevron.backward")
-                    .foregroundColor(.black)
+                    .foregroundColor(Color("MainColor"))
             }
         }
     }


### PR DESCRIPTION
<img src = "https://user-images.githubusercontent.com/67509011/201609982-f7411245-15ff-45eb-a588-1fd93f434912.png" width="30%" height="30%">  <img src = "https://user-images.githubusercontent.com/67509011/201609995-eb3bbd6d-2fdb-47be-9e60-ee53f8574616.png" width="30%" height="30%">


## 작업사항
북마크뷰와 분위기뷰의 back button 모양과 위치를 통일시켜줬습니다.

## 이슈 번호

- #69 

## 특이사항
- @Anti9uA  분위기뷰의 네비게이션 타이틀과 이미지 사이의 패딩값이 하이파이와 다르게 구현되어있습니다 수정 부탁드립니다!
