### PR TITLE
[fix][feat] #43 메인 카드뷰 하단 여백 추가, 카드뷰 opacity 추가, Text 왼쪽 정렬

### DIFF
--- a/ChilledCafe/Views/Main/FullCardScrollView.swift
+++ b/ChilledCafe/Views/Main/FullCardScrollView.swift
@@ -19,6 +19,7 @@ struct FullCardScrollView: View {
                     FullCardView(cafe: cafe)
                 })
             }
+            Spacer(minLength: UIScreen.getHeight(30))
         }
     }
 }

--- a/ChilledCafe/Views/Main/FullCardView.swift
+++ b/ChilledCafe/Views/Main/FullCardView.swift
@@ -21,60 +21,66 @@ struct FullCardView: View {
             .frame(width: UIScreen.getWidth(350), height: UIScreen.getHeight(250))
             .cornerRadius(4, corners: .allCorners)
             .overlay(content: {
-                VStack {
-                    HStack(spacing: 16) {
-                        Spacer()
-                        // MARK: - AR 토글 여부
-                        if cafe.ar {
-                            Button(action: {
-                                // TODO: AR 토글 동작
-                            }, label: {
-                                Image("ar")
-                                    .resizable()
-                                    .frame(width: UIScreen.getWidth(30), height: UIScreen.getHeight(30))
-                                    .foregroundColor(.white)
-                            })
+                ZStack {
+                    Color.black
+                        .opacity(0.4)
+                        .cornerRadius(4, corners: .allCorners)
+                    VStack {
+                        HStack(spacing: 16) {
+                            Spacer()
+                            // MARK: - AR 토글 여부
+                            if cafe.ar {
+                                Button(action: {
+                                    // TODO: AR 토글 동작
+                                }, label: {
+                                    Image("ar")
+                                        .resizable()
+                                        .frame(width: UIScreen.getWidth(30), height: UIScreen.getHeight(30))
+                                        .foregroundColor(.white)
+                                })
+                            }
+                            // MARK: - 북마크 토글 여부
+                            if cafe.bookmark {
+                                Button(action: {
+                                    // TODO: 북마크 토글 동작
+                                }, label: {
+                                    Image("bookmarkToggled")
+                                        .resizable()
+                                        .frame(width: UIScreen.getWidth(30), height: UIScreen.getHeight(30))
+                                        .foregroundColor(Color(.orange))
+                                })
+                            } else {
+                                Button(action: {
+                                    // TODO: 북마크 토글 동작
+                                }, label: {
+                                    Image("bookmarkBlack")
+                                        .resizable()
+                                        .frame(width: UIScreen.getWidth(30), height: UIScreen.getHeight(30))
+                                        .foregroundColor(Color(.white))
+                                })
+                            }
                         }
-                        // MARK: - 북마크 토글 여부
-                        if cafe.bookmark {
-                            Button(action: {
-                                // TODO: 북마크 토글 동작
-                            }, label: {
-                                Image("bookmarkToggled")
-                                    .resizable()
-                                    .frame(width: UIScreen.getWidth(30), height: UIScreen.getHeight(30))
-                                    .foregroundColor(Color(.orange))
-                            })
-                        } else {
-                            Button(action: {
-                                // TODO: 북마크 토글 동작
-                            }, label: {
-                                Image("bookmarkBlack")
-                                    .resizable()
-                                    .frame(width: UIScreen.getWidth(30), height: UIScreen.getHeight(30))
-                                    .foregroundColor(Color(.white))
-                            })
+                        Spacer()
+                        // MARK: - 카페 이름
+                        HStack {
+                            Text(cafe.name)
+                                .customTitle2()
+                                .foregroundColor(.white)
+                            Spacer()
                         }
+                        .padding(EdgeInsets(top: 0, leading: 0, bottom: UIScreen.getHeight(6), trailing: 0))
+                        // MARK: - 카페 설명
+                        HStack {
+                            Text(cafe.shortIntroduction)
+                                .customSubhead3()
+                                .multilineTextAlignment(.leading)
+                                .foregroundColor(.white)
+                            Spacer()
+                        }
+                        
                     }
-                    Spacer()
-                    // MARK: - 카페 이름
-                    HStack {
-                        Text(cafe.name)
-                            .customTitle2()
-                            .foregroundColor(.white)
-                        Spacer()
-                    }
-                    .padding(EdgeInsets(top: 0, leading: 0, bottom: UIScreen.getHeight(6), trailing: 0))
-                    // MARK: - 카페 설명
-                    HStack {
-                        Text(cafe.shortIntroduction)
-                            .customSubhead3()
-                            .foregroundColor(.white)
-                        Spacer()
-                    }
-                       
+                    .padding(EdgeInsets(top: UIScreen.getHeight(20), leading: UIScreen.getWidth(20), bottom: UIScreen.getHeight(20), trailing: UIScreen.getWidth(20)))
                 }
-                .padding(EdgeInsets(top: UIScreen.getHeight(20), leading: UIScreen.getWidth(20), bottom: UIScreen.getHeight(20), trailing: UIScreen.getWidth(20)))
             })
     }  
 }


### PR DESCRIPTION
<img src = "https://user-images.githubusercontent.com/67509011/201628741-5a430292-21d9-45c4-8764-45526830b6f3.png" width="30%" height="30%">

## 작업사항
메인 페이지 카드뷰 하단에 `Spacer(minLength: UIScreen.getHeight(30))` 여백을 추가해줬습니다

카드뷰 이미지 위에 검은색 opacity가 적용된 뷰를 덮어씌었습니다

카페 설명 Text가 길어져서 두 줄 이상 되었을때 왼쪽으로 정렬되게 수정해줬습니다

## 이슈 번호

- #43 

