### PR TITLE
[feat] #76 #78 온보딩 분기 처리 로직 구현

### DIFF
--- a/ChilledCafe/ChilledCafeApp.swift
+++ b/ChilledCafe/ChilledCafeApp.swift
@@ -21,11 +21,20 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 @main
 struct ChilledCafeApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
+    @AppStorage("isFirst") private var isFirst: Bool = true
+    @StateObject var firebaseSM: FirebaseStorageManager = FirebaseStorageManager()
     
     
     var body: some Scene {
         WindowGroup {
-            IntroView()
+            NavigationView {
+                if isFirst {
+                    IntroView()
+                } else {
+                    MainView(firebaseSM: firebaseSM, ifFirst: true)
+                }
+            }
+            .accentColor(Color("MainColor"))
         }
     }
 }

--- a/ChilledCafe/FIrebase/FirebaseStorageManager.swift
+++ b/ChilledCafe/FIrebase/FirebaseStorageManager.swift
@@ -15,7 +15,7 @@ class FirebaseStorageManager: ObservableObject {
     
     @Published var cafeList: [Cafes] = []
     @Published var cafeListClassification: [String: [Cafes]] = [:]
-    @Published var selectedCategory: String = "거대한 공간"
+    @Published var selectedCategory: String = "AR 경험"
     @Published var bookmarkedCafeList: [Cafes] = []
     
     init() {

--- a/ChilledCafe/Views/Main/MainView.swift
+++ b/ChilledCafe/Views/Main/MainView.swift
@@ -8,7 +8,8 @@
 import SwiftUI
 
 struct MainView: View {
-    @StateObject var firebaseSM: FirebaseStorageManager = FirebaseStorageManager()
+    @ObservedObject var firebaseSM: FirebaseStorageManager
+    @AppStorage("isFirst") var ifFirst: Bool = true
     
     var body: some View {
         VStack(spacing: 0) {
@@ -44,6 +45,6 @@ struct MainView: View {
 
 struct MainView_Previews: PreviewProvider {
     static var previews: some View {
-        MainView()
+        MainView(firebaseSM: FirebaseStorageManager(), ifFirst: true)
     }
 }

--- a/ChilledCafe/Views/MoodView/MoodImageView.swift
+++ b/ChilledCafe/Views/MoodView/MoodImageView.swift
@@ -77,9 +77,3 @@ struct MoodImageView: View {
         .navigationBarHidden(true)
     }
 }
-
-struct MoodImageView_Previews: PreviewProvider {
-    static var previews: some View {
-        MainView()
-    }
-}

--- a/ChilledCafe/Views/MoodView/MoodView.swift
+++ b/ChilledCafe/Views/MoodView/MoodView.swift
@@ -84,9 +84,3 @@ struct MoodView: View {
     }
     
 }
-
-struct GalleryView_Previews: PreviewProvider {
-    static var previews: some View {
-        MainView()
-    }
-}

--- a/ChilledCafe/Views/Onboarding/IntroView.swift
+++ b/ChilledCafe/Views/Onboarding/IntroView.swift
@@ -7,8 +7,9 @@
 import SwiftUI
 
 struct IntroView: View {
+    @AppStorage("isFirst") var isFirst: Bool = true
+    
     var body: some View {
-        NavigationView {
             ZStack {
                 Image("OnboardingBackground")
                     .resizable()
@@ -16,15 +17,16 @@ struct IntroView: View {
                     .ignoresSafeArea()
                 VStack {
                     Spacer()
-                    NavigationLink(destination: MainView(), label: {
+                    Button(action: {
+                        isFirst = false
+                    }, label: {
                         CustomConfirmButtonView(title: "Let's go!")
                     })
+                    
                 }
                 .padding(EdgeInsets(top: 0, leading: 0, bottom: UIScreen.getHeight(60), trailing: 0))
             }
             .navigationBarHidden(true)
-        }
-        .accentColor(Color("MainColor"))
     }
 }
 

--- a/ChilledCafe/Views/Onboarding/SelectAtmosphereView.swift
+++ b/ChilledCafe/Views/Onboarding/SelectAtmosphereView.swift
@@ -68,9 +68,9 @@ struct SelectAtmosphereView: View {
                 VStack {
                     Spacer()
                     if checked.filter { $0 == true }.isEmpty == false {
-                        NavigationLink(destination: MainView().environmentObject(FirebaseStorageManager()), label: {
-                            CustomConfirmButtonView(title: "ready!")
-                        })
+//                        NavigationLink(destination: MainView().environmentObject(FirebaseStorageManager()), label: {
+//                            CustomConfirmButtonView(title: "ready!")
+//                        })
                     }
                 }
             }


### PR DESCRIPTION
## 작업사항
`@AppStorage`의 `isFirst`에 앱의 최초실행을 구분하여 최초실행시 온보딩뷰인 `IntroView`가 보이고 2번째부터는 바로 `MainView`로 넘어가게 구현하였습니다.

```swift
@AppStorage("isFirst") private var isFirst: Bool = true

NavigationView {
    if isFirst {
        IntroView()
    } else {
        MainView(firebaseSM: firebaseSM, ifFirst: true)
    }
}
```

## 이슈 번호

- close #76 
- close #78 

